### PR TITLE
feat: player stats display components

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@hookform/resolvers": "^3.9.0",
     "@mui/icons-material": "^6.0.2",
     "@mui/material": "^6.0.2",
+    "@mui/x-data-grid": "^7.18.0",
     "@nivo/bar": "^0.87.0",
     "@nivo/core": "^0.87.0",
     "@nivo/line": "^0.87.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@mui/material':
         specifier: ^6.0.2
         version: 6.0.2(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/x-data-grid':
+        specifier: ^7.18.0
+        version: 7.18.0(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react@18.3.1))(@mui/material@6.0.2(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.0.2(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@nivo/bar':
         specifier: ^0.87.0
         version: 0.87.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1383,6 +1386,16 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/utils@5.16.6':
+    resolution: {integrity: sha512-tWiQqlhxAt3KENNiSRL+DIn9H5xNVK6Jjf70x3PnfQPz1MPBdh7yyIcAyVBT9xiw7hP3SomRhPR7hzBMBCjqEA==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@mui/utils@6.0.2':
     resolution: {integrity: sha512-TeFrYsxcmeoDSlkoPhX+LjIuuqC5Pyj+xz2kRceKCkUpwMNTEeVOfowXDPe+mboZwmpJ5ZxP4eiAgQMdeEasjg==}
     engines: {node: '>=14.0.0'}
@@ -1392,6 +1405,28 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@mui/x-data-grid@7.18.0':
+    resolution: {integrity: sha512-41UjJbRxWk+Yk/lfvaO55Pwo5p+F5s3rOTiHLl53ikCT5GuJ5OCCvik0Bi3c6DzTuUBdrEucae2618rydc2DGw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^5.15.14 || ^6.0.0
+      '@mui/system': ^5.15.14 || ^6.0.0
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
+  '@mui/x-internals@7.18.0':
+    resolution: {integrity: sha512-lzCHOWIR0cAIY1bGrWSprYerahbnH5C31ql/2OWCEjcngL2NAV1M6oKI2Vp4HheqzJ822c60UyWyapvyjSzY/A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0
 
   '@nivo/annotations@0.87.0':
     resolution: {integrity: sha512-4Xk/soEmi706iOKszjX1EcGLBNIvhMifCYXOuLIFlMAXqhw1x2YS7PxickVSskdSzJCwJX4NgQ/R/9u6nxc5OA==}
@@ -4949,6 +4984,9 @@ packages:
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
   resolve-dir@1.0.1:
     resolution: {integrity: sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==}
     engines: {node: '>=0.10.0'}
@@ -7156,6 +7194,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.5
 
+  '@mui/utils@5.16.6(@types/react@18.3.5)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.6
+      '@mui/types': 7.2.16(@types/react@18.3.5)
+      '@types/prop-types': 15.7.12
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-is: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.5
+
   '@mui/utils@6.0.2(@types/react@18.3.5)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.6
@@ -7167,6 +7217,32 @@ snapshots:
       react-is: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.5
+
+  '@mui/x-data-grid@7.18.0(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react@18.3.1))(@mui/material@6.0.2(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.0.2(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.6
+      '@mui/material': 6.0.2(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/system': 6.0.2(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react@18.3.1)
+      '@mui/utils': 5.16.6(@types/react@18.3.5)(react@18.3.1)
+      '@mui/x-internals': 7.18.0(@types/react@18.3.5)(react@18.3.1)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      '@emotion/react': 11.13.3(@types/react@18.3.5)(react@18.3.1)
+      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.5)(react@18.3.1))(@types/react@18.3.5)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-internals@7.18.0(@types/react@18.3.5)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.25.6
+      '@mui/utils': 5.16.6(@types/react@18.3.5)(react@18.3.1)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@nivo/annotations@0.87.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -11303,6 +11379,8 @@ snapshots:
   requireindex@1.2.0: {}
 
   requires-port@1.0.0: {}
+
+  reselect@5.1.1: {}
 
   resolve-dir@1.0.1:
     dependencies:

--- a/src/features/player-instance/types/index.ts
+++ b/src/features/player-instance/types/index.ts
@@ -1,4 +1,4 @@
-export type Stats = {
+export type PlayerStats = {
   player_id: number,
   full_name: string,
   stats: Array<string>,
@@ -11,16 +11,40 @@ export type Stats = {
   shorthanded_goals: number
 };
 
+export type PlayerByTeamStats = {
+  GP: number,
+  G: number,
+  A: number,
+  PIM: number,
+  PTS: number,
+  PPG: number,
+  SHG: number
+};
+
 export type Player = {
   player_id: number,
   full_name: string,
   stats_url: string,
-  stats: Stats,
+  stats: PlayerStats,
+};
+
+export type TeamStats = {
+  [key: string]: string
 };
 
 export type PlayerByTeam = {
   player_id: number,
   full_name: string,
   stats_url: string,
-  team_stats: {key: Array<string>},
+  team_stats: Record<string, PlayerByTeamStats>,
 };
+
+export enum STAT_KEYS {
+  games_played = 'GP',
+  goals = 'G',
+  assists = 'A',
+  penalty_minutes = 'PIM',
+  points = 'PTS',
+  powerplay_goals = 'PPG',
+  shorthanded_goals = 'SHG'
+}

--- a/src/pages/Player.tsx
+++ b/src/pages/Player.tsx
@@ -2,7 +2,8 @@ import { useParams, useSearchParams } from "react-router-dom";
 import type { FunctionComponent } from "../common/types";
 import { useQuery } from "@tanstack/react-query";
 import { getPlayer, getPlayerByTeam, SORT_TYPE } from "../features/player-instance/api";
-import { Container } from "@mui/material";
+import { Container, Link, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typography } from "@mui/material";
+import type { PlayerStats, PlayerByTeamStats } from "../features/player-instance/types";
 
 export const Player = (): FunctionComponent => {
   const parameters = useParams()
@@ -16,24 +17,109 @@ export const Player = (): FunctionComponent => {
     enabled: !!playerId && !sortByTeam
   });
 
-  const {data: playerByTeamData, isLoading: isPlayerByTeamLoading} = useQuery({
+  const {data: playerByTeamData, isLoading: isPlayerTeamDataLoading} = useQuery({
     queryKey: ['player-by-team', playerId],
     queryFn: async () => playerId ? getPlayerByTeam(playerId, {sort: SORT_TYPE.TEAM}) : Promise.reject(new Error('Player ID is undefined')),
-    enabled: !!playerId && sortByTeam
+    enabled: true
   });
+
+  function renderStatsByTeam(stats: Record<string, PlayerByTeamStats>): JSX.Element {
+    const teamStats = [];
+    for (const key in stats) {
+      teamStats.push(
+        <TableRow>
+          <TableCell>{key}</TableCell>
+          <TableCell>{stats[key]?.GP}</TableCell>
+          <TableCell>{stats[key]?.G}</TableCell>
+          <TableCell>{stats[key]?.A}</TableCell>
+          <TableCell>{stats[key]?.PIM}</TableCell>
+          <TableCell>{stats[key]?.PTS}</TableCell>
+          <TableCell>{stats[key]?.PPG}</TableCell>
+          <TableCell>{stats[key]?.SHG}</TableCell>
+        </TableRow>
+      );
+    }
+    
+    return (<>{teamStats}</>);
+  }      
+
+  function renderStats(stats: PlayerStats): JSX.Element {
+    return (
+      <TableRow>
+        <TableCell>{stats.games_played}</TableCell>
+        <TableCell>{stats.goals}</TableCell>
+        <TableCell>{stats.assists}</TableCell>
+        <TableCell>{stats.penalty_minutes}</TableCell>
+        <TableCell>{stats.points}</TableCell>
+        <TableCell>{stats.powerplay_goals}</TableCell>
+        <TableCell>{stats.shorthanded_goals}</TableCell>
+      </TableRow>
+    );
+  }
 
   return (
     <div>
-      <p>Player ID: {playerId}</p>
-      {isPlayerDataLoading || isPlayerByTeamLoading && (
-        <p>Loading...</p>
+      {(isPlayerDataLoading || isPlayerTeamDataLoading) && (
+        <p>Loading stats...</p>
       )}
       <Container maxWidth="sm">
         {playerData && (
-          JSON.stringify(playerData)
-        )}
-        {playerByTeamData && (
-          JSON.stringify(playerByTeamData)
+          <>
+            <Paper elevation={0}  sx={{marginBottom: '8px', padding: '4px'}}>
+              <Typography variant="h5" >
+                <Link href={playerData.stats_url}>
+                {playerData.full_name} - {playerId}
+                </Link>
+              </Typography>
+            </Paper>
+            <Paper sx={{marginBottom: '8px', padding: '4px'}}>
+              <Typography variant="h4">
+                Lifetime stats
+              </Typography>
+              <TableContainer>
+                <Table sx={{ minWidth: '100%'}}>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>GP</TableCell>
+                      <TableCell>G</TableCell>
+                      <TableCell>ASS</TableCell>
+                      <TableCell>PIM</TableCell>
+                      <TableCell>PTS</TableCell>
+                      <TableCell>PPG</TableCell>
+                      <TableCell>SHG</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {renderStats(playerData.stats)}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            </Paper>
+            <Paper sx={{marginBottom: '8px', padding: '4px'}}>
+              <Typography variant="h4">
+                Team stats
+              </Typography>
+              <TableContainer>
+                <Table sx={{ minWidth: '100%'}}>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Team</TableCell>
+                      <TableCell>GP</TableCell>
+                      <TableCell>G</TableCell>
+                      <TableCell>ASS</TableCell>
+                      <TableCell>PIM</TableCell>
+                      <TableCell>Points</TableCell>
+                      <TableCell>PPG</TableCell>
+                      <TableCell>SHG</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {playerByTeamData?.team_stats && renderStatsByTeam(playerByTeamData.team_stats)}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            </Paper>
+          </>
         )}
       </Container>
     </div>

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -9,7 +9,7 @@ export const AppWrapper = (): JSX.Element => {
         <AppHeader />
       </Container>
       <Container maxWidth="sm">
-        <Box sx={{ height: '80vh' }} >
+        <Box sx={{ minHeight: '80vh' }} >
           <Outlet />
         </Box>
       </Container>


### PR DESCRIPTION
Adds the two display components for lifetime and team stats to the player instance page. Updated types. 

These should be refactored into reusable components in `src/features/player-instance` but I'll save that work for later.

![Screen Shot 2024-10-03 at 10 56 39 AM](https://github.com/user-attachments/assets/790456e9-3c04-4c02-81a7-7fcce9128970)
